### PR TITLE
Adding parameter

### DIFF
--- a/openstack-heat/standalone/2nic/f5_ve_standalone_2_nic_bigiq_license.yaml
+++ b/openstack-heat/standalone/2nic/f5_ve_standalone_2_nic_bigiq_license.yaml
@@ -21,6 +21,10 @@ parameters:
     label: Use Config Drive
     description: Use config drive to provider meta and user data.
     default: false 
+  f5_ve_os_ssh_key:
+    type: string
+    default: demokeypair
+    description: Name of an existing key pair to use for the instance
   admin_username:
     type: string
     label: F5 VE Admin UserName


### PR DESCRIPTION
Added "f5_ve_os_ssh_key" parameter because it was missing but referenced later on. 

Otherwise you get below error when creating the stack:
"The grouped parameter f5_ve_os_ssh_key does not reference a valid parameter."